### PR TITLE
受注できる記事数の制限

### DIFF
--- a/src/components/recruitingArticles.tsx
+++ b/src/components/recruitingArticles.tsx
@@ -40,10 +40,9 @@ const RecruitingArticles: React.SFC<any> = ({
   dataSource,
   editArticle,
   isLoading,
-  position
+  position,
+  amountOfArticles
 }) => {
-  console.log(position)
-  
   return (
     <div>
       <h1>募集中の記事</h1>
@@ -70,17 +69,19 @@ const RecruitingArticles: React.SFC<any> = ({
         />
         {
           position === 'writer' ? (
-            <Column
-              title='受注'
-              render={({ id }) => (
-                <Popconfirm
-                  title='本当に受注しますか？'
-                  onConfirm={() => editArticle({id})}
-                >
-                  <Button size='small'>受注する</Button>
-                </Popconfirm>
-              )}
-            />
+            amountOfArticles <= 2 ? (
+              <Column
+                title='受注'
+                render={({ id }) => (
+                  <Popconfirm
+                    title='本当に受注しますか？'
+                    onConfirm={() => editArticle({id})}
+                  >
+                    <Button size='small'>受注する</Button>
+                  </Popconfirm>
+                )}
+              />
+            ) : null
           ) : null
         }
       </List>

--- a/src/containers/recruitingArticles.ts
+++ b/src/containers/recruitingArticles.ts
@@ -54,14 +54,15 @@ const WithHandlers = withHandlers <RouteComponentProps | any, ActionProps>({
   fetchData: ({ receiveData, receiveAmount }: any) => async () => {
 
     // amount of writer's own articles
-    const myArticles = (await read(`/users/${await getUid()}/articles`)).val()
-    let myArticleAmount = 0
-    Object.keys(myArticles).forEach((articleType: string) => {
-      if (articleType !== 'wrotes') {
-        myArticleAmount += Object.keys(myArticles[articleType]).length
-      }
+    listenStart(`/users/${await getUid()}/articles`, (myArticles: any) => {
+      let myArticleAmount = 0
+      Object.keys(myArticles).forEach((articleType: string) => {
+        if (articleType !== 'wrotes') {
+          myArticleAmount += Object.keys(myArticles[articleType]).length
+        }
+      })
+      receiveAmount({ amountOfArticles: myArticleAmount })
     })
-    receiveAmount({ amountOfArticles: myArticleAmount })
     
     
     

--- a/src/containers/recruitingArticles.ts
+++ b/src/containers/recruitingArticles.ts
@@ -12,18 +12,21 @@ type State = {
   dataSource: any
   isLoading: boolean
   position: string
+  amountOfArticles: number
 }
 
 type StateUpdates = {
   receiveData: (dataSource: any) => State
   receivePosition: ({ position }: any) => State
+  receiveAmount: ({ position }: any) => State
 }
 
 const stateHandlers = withStateHandlers <State, StateUpdates> (
   {
     dataSource: [],
     isLoading: true,
-    position: ''
+    position: '',
+    amountOfArticles: 0
   },
   {
     receiveData: (props) => (dataSource: any) => ({
@@ -31,7 +34,8 @@ const stateHandlers = withStateHandlers <State, StateUpdates> (
       dataSource,
       isLoading: false
     }),
-    receivePosition: (props) => ({ position }) => ({ ...props, position })
+    receivePosition: (props) => ({ position }) => ({ ...props, position }),
+    receiveAmount: (props) => ({ amountOfArticles }) => ({ ...props, amountOfArticles })
   }
 )
 
@@ -47,7 +51,20 @@ const WithHandlers = withHandlers <RouteComponentProps | any, ActionProps>({
     const position = (await read(`/users/${uid}/position`)).val()
     receivePosition({ position })
   },
-  fetchData: ({ receiveData }: any) => () => {
+  fetchData: ({ receiveData, receiveAmount }: any) => async () => {
+
+    // amount of writer's own articles
+    const myArticles = (await read(`/users/${await getUid()}/articles`)).val()
+    let myArticleAmount = 0
+    Object.keys(myArticles).forEach((articleType: string) => {
+      if (articleType !== 'wrotes') {
+        myArticleAmount += Object.keys(myArticles[articleType]).length
+      }
+    })
+    receiveAmount({ amountOfArticles: myArticleAmount })
+    
+    
+    
     listenStart('/articles', (val: any) => {
       if (val) {
         let dataSource: any = []


### PR DESCRIPTION
## やること
`執筆中` `検品中` `差し戻し` の３つの記事の合計が３以上の場合は新たに記事を受注できないようにする．